### PR TITLE
fix: bump deprecated Lambda runtime to nodejs12.x

### DIFF
--- a/amplify/backend/auth/cognitocf0c6096/cognitocf0c6096-cloudformation-template.yml
+++ b/amplify/backend/auth/cognitocf0c6096/cognitocf0c6096-cloudformation-template.yml
@@ -263,7 +263,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This project was using a Lambda runtime that is deprecated since March 2020. This bumps it to nodejs12.x.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
